### PR TITLE
Look up user's NN using thier email/name

### DIFF
--- a/supportbot/request_handler.py
+++ b/supportbot/request_handler.py
@@ -10,8 +10,9 @@ def handle_support_request(app, config, user_id, channel_id, message_ts):
         thread_ts=message_ts,
         text=f"This is a reply to <@{user_id}>! It looks like "
              f"your email is {user.email} {'and' if user.network_number else 'but'} your network number "
-             f"{'is ' + user.network_number if user.network_number else 'could not be found'}. "
+             f"{'is ' + str(user.network_number) if user.network_number else 'could not be found'}. "
              f"Here's a diagnostics report to help our volunteers:",
     )
 
-    upload_report_file(app, "DATA\n" * 43, channel_id, message_ts, user.network_number)
+    if user.network_number:
+        upload_report_file(app, "DATA\n" * 43, channel_id, message_ts, user.network_number)


### PR DESCRIPTION
When the Slackbot is attempting to determine a user's NN, it now uses the following logic:

1. If the user has a NN in their profile, use that. If not:
2. If the user's email results in a NN match, use that. If not:
3. If the user's name results in a NN match, use that

Otherwise the slackbot errors with "could not be found"