### PR TITLE
Remove @user feature & re-word the bot text to indicate NN source

### DIFF
--- a/supportbot/supportbot/app.py
+++ b/supportbot/supportbot/app.py
@@ -57,13 +57,7 @@ def run_app(config):
         else:
             manual_number = None
 
-        at_member_input = view['state']['values']['checkboxInputBlock']['at_message_toggle-action']['selected_options']
-        if len(at_member_input) > 0:
-            at_member = True
-        else:
-            at_member = False
-
-        handle_support_request(app, config, metadata['user'], metadata['channel'], metadata['ts'], manual_number=manual_number, at_member=at_member)
+        handle_support_request(app, config, metadata['user'], metadata['channel'], metadata['ts'], manual_number=manual_number)
 
     # Automated response flow in response to message in Support channel
 
@@ -130,7 +124,7 @@ def run_app(config):
             manual_number = manual_number_input['value']
         else:
             manual_number = None
-        handle_support_request(app, config, metadata['user'], metadata['channel'], metadata['ts'], manual_number=manual_number, at_member = False)
+        handle_support_request(app, config, metadata['user'], metadata['channel'], metadata['ts'], manual_number=manual_number)
 
 
     SocketModeHandler(app, os.environ.get("SLACK_APP_TOKEN")).start()

--- a/supportbot/supportbot/request_handler.py
+++ b/supportbot/supportbot/request_handler.py
@@ -9,13 +9,21 @@ def nn_to_map_url(nn):
     base = 'https://www.nycmesh.net/map/nodes/'
     return f'<{base}-{nn}|NN{nn}>'
 
-def handle_support_request(app, config, user_id, channel_id, message_ts, manual_number=None, at_member = True):
+def handle_support_request(app, config, user_id, channel_id, message_ts, manual_number=None):
     user = MeshUser(app, user_id, config['nn_property_id'], manual_number=manual_number)
 
-    if at_member:
-        text = f"This is a reply to <@{user_id}>! It looks like your email is {user.email} {'and' if user.network_number else 'but'} your network number {'is ' + nn_to_map_url(user.network_number) if user.network_number else 'could not be found'}. {f'Diagnostic report running...' if user.network_number else ''}"
+    if not user.network_number:
+        text = (
+            "A network number was not provided and could not be found automatically. "
+            "A volunteer will assist you shortly. Please try to find your network or "
+            "install number so that we can locate your connection in our systems."
+        )
     else:
-        text = f"The network number {'is ' + nn_to_map_url(user.network_number) if user.network_number else 'could not be found'}. {f'Diagnostic report running...' if user.network_number else ''}"
+        text = (
+            f"The network number {'entered was' if manual_number else ''} "
+            f"{nn_to_map_url(user.network_number) + (' was automatically detected' if not manual_number else '')}. "
+            f"Diagnostic report running..."
+        )
 
     app.client.chat_postMessage(
         channel=channel_id,

--- a/supportbot/supportbot/request_handler.py
+++ b/supportbot/supportbot/request_handler.py
@@ -14,9 +14,10 @@ def handle_support_request(app, config, user_id, channel_id, message_ts, manual_
 
     if not user.network_number:
         text = (
-            "A network number was not provided and could not be found automatically. "
-            "A volunteer will assist you shortly. Please try to find your network or "
-            "install number so that we can locate your connection in our systems."
+            "The Install Number could not be automatically determined.  You can find your "
+            "Install Number by searching the registered email for the Subject "
+            "\"NYC Mesh Rooftop Install.\"  Providing this number will help volunteers locate "
+            "your number in our system to better assist you."
         )
     else:
         text = (

--- a/supportbot/supportbot/utils/block_kit_templates.py
+++ b/supportbot/supportbot/utils/block_kit_templates.py
@@ -57,47 +57,13 @@ def confrimation_dialog_block_kit(channel_id, message_ts, user_id, nn=None):
                 ]
             },
             {
-            "type": "input",
-            'optional': False,
-            "block_id": "numberInputBlock",
-            "element": get_default_nn_element_field(nn),
-            "label": {
-                "type": "plain_text",
-                "text": "NN or Install Number:",
-                "emoji": True
-            }
-            },
-            {
                 "type": "input",
-                'optional': True,
-                "block_id": "checkboxInputBlock",
-                "element": {
-                    "type": "checkboxes",
-                    "action_id": "at_message_toggle-action",
-                    "initial_options": [
-                        {
-                            "text": {
-                                "type": "plain_text",
-                                "text": "Yes, @ member",
-                                "emoji": True
-                            },
-                            "value": "at_message_checkbox"
-                        }
-                    ],
-                    "options": [
-                        {
-                            "text": {
-                                "type": "plain_text",
-                                "text": "Yes, @ member",
-                                "emoji": True
-                            },
-                            "value": "at_message_checkbox"
-                        }
-                    ]
-                },
+                'optional': False,
+                "block_id": "numberInputBlock",
+                "element": get_default_nn_element_field(nn),
                 "label": {
                     "type": "plain_text",
-                    "text": "@ member from original message?",
+                    "text": "NN or Install Number:",
                     "emoji": True
                 }
             }


### PR DESCRIPTION
Removes the ability to @ members, since this feature is rarely used intentionally, and notifications are automatically delivered for thread replies anyway.

The bot now has only three response modes. 

When an NN is provided via the dialog box (regardless of whether it was auto-filled or manually edited) the bot says:

> The network number entered was [NN240](https://www.nycmesh.net/map/nodes/-240). Diagnostic report running...

When no NN is provided in the dialog box, and the bot finds one, it says

> The network number  [NN240](https://www.nycmesh.net/map/nodes/-240) was automatically detected. Diagnostic report running...

If no NN is provided, and it cannot be automatically found, the bot says:

> A network number was not provided and could not be found automatically. A volunteer will assist you shortly. Please try to find your network or install number so that we can locate your connection in our systems.
