### PR TITLE
Fix: stop using deprecated file upload API

### DIFF
--- a/supportbot/supportbot/utils/diagnostics_report.py
+++ b/supportbot/supportbot/utils/diagnostics_report.py
@@ -14,10 +14,9 @@ def upload_report_file(
     app, report_txt, channel_id, thread_id, network_number, initial_comment
 ):
     timestamp = datetime.datetime.now(tz=timezone("US/Eastern"))
-    response = app.client.files_upload(
-        channels=channel_id,
+    response = app.client.files_upload_v2(
+        channel=channel_id,
         content=report_txt,
-        filetype="txt",
         filename=f"diagnostics_{network_number}_{timestamp.strftime('%Y-%m-%dT%H:%M:%S')}.txt",
         title=f"Diagnostics Report - NN {network_number} on {timestamp.strftime('%Y-%m-%d at %I:%M %p')}",
         thread_ts=thread_id,


### PR DESCRIPTION
Switch from the deprecated v1 file upload function, to the new v2 version. Avoids an outage due to the upcoming API changes: https://nycmesh.slack.com/archives/C045QM9TDMZ/p1714750166196559