### PR TITLE
Remove 8k NN limit, we validate this in python now

### DIFF
--- a/bin/nn_stats.sh
+++ b/bin/nn_stats.sh
@@ -16,8 +16,8 @@ echo "Network Number: $1";
 # test if input is a number under 8000
 
 if (( $1 )) 2>/dev/null; then
-  if (( $1 > 8000 )) ; then
-    echo "FATAL: Network numbers are below 8000."
+  if (( $1 < 0 )) ; then
+    echo "FATAL: Network numbers are greater than 0."
     exit
   fi
 else


### PR DESCRIPTION
Replace the `< 8000` filter with a ` > 0` filter, some testing NNs exist above 8k, and there is pretty good validation within the Python code these days so this was mostly duplicative