### PR TITLE
Update docker base image to 3.11-slim-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.9-slim-buster
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes an issue where `ping`, `ssh`, etc are not available